### PR TITLE
add endorsement button for US1 front end

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -97,6 +97,10 @@
 		<a component="post/reply" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
 		<a component="post/quote" href="#" class="btn-ghost-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
 
+		<a component="post/endorse" href="#" class="btn-ghost-sm" title="Endorse">
+			<i class="fa fa-fw fa-thumbs-up text-success"></i> Endorse
+		</a>
+
 		{{{ if !reputation:disabled }}}
 		<div class="d-flex votes align-items-center">
 			<a component="post/upvote" href="#" class="btn-ghost-sm{{{ if posts.upvoted }}} upvoted{{{ end }}}" title="[[topic:upvote-post]]">


### PR DESCRIPTION
This PR adds the endorsement button to the frontend as part of the US1 feature.
- Implemented the button in the topic tools section.
- Addressed issues with theme setup and resolved the "theme-not-found" error.
<img width="1458" alt="Screenshot 2024-10-10 at 21 04 28" src="https://github.com/user-attachments/assets/765559ec-0c10-4d02-8f54-ffc308ac2b6c">
